### PR TITLE
Avoid inserting an extra Rack::Timeout middleware

### DIFF
--- a/lib/pry/shell/patches/rack_timeout.rb
+++ b/lib/pry/shell/patches/rack_timeout.rb
@@ -14,7 +14,7 @@ class Pry
 end
 
 begin
-  require "rack-timeout"
+  require "rack/timeout/base"
 
   Rack::Timeout::Scheduler::Timeout.prepend(Pry::Shell::Patches::RackTimeout)
 rescue LoadError # rubocop:disable Lint/SuppressedException


### PR DESCRIPTION
Calling `require 'rack-timeout'` will cause a Railtie to insert a `Rack::Timeout` middleware with a 15-second timeout
(https://github.com/zombocom/rack-timeout/blob/main/lib/rack/timeout/rails.rb) on a Rails application. This may cause a duplicate middleware to be inserted if the application manually inserts `Rack::Timeout` already.

Since we don't actually want a new middleware to be inserted and just want to patch the internals of `rack-timeout`, we can just call `require 'rack/timeout/base'` instead.

Relates to https://gitlab.com/gitlab-org/gitlab-development-kit/-/issues/1913